### PR TITLE
Fixes to make the extension runnable on mercurial 4.0

### DIFF
--- a/blametrail.py
+++ b/blametrail.py
@@ -196,7 +196,10 @@ class changeset_printer(object):
                 lines_from = (int(m.group(1)), int(m.group(2)))
                 lines_to = (int(m.group(3)), int(m.group(4)))
 
-                diffline = self.ui.popbuffer()
+                try:
+                    diffline = self.ui.popbuffer()
+                except IndexError:
+                    diffline = None
 
                 if lines_to[0] <= self.line <= lines_to[0] + lines_to[1]:
                     # this is an interesting hunk!

--- a/blametrail.py
+++ b/blametrail.py
@@ -96,7 +96,7 @@ def blame_trail(origfn, ui, repo, *pats, **opts):
 
         print
 
-    rev = original_rev
+    rev = str(original_rev)
     line = original_line
 
     # print the summary of the diff

--- a/blametrail.py
+++ b/blametrail.py
@@ -7,6 +7,7 @@ from mercurial.node import hex, short
 from mercurial import cmdutil, nullrev
 from mercurial import scmutil, patch, util, encoding
 
+testedwith = '4.0'
 
 def _(s):
     return s

--- a/blametrail.py
+++ b/blametrail.py
@@ -199,6 +199,7 @@ class changeset_printer(object):
                 try:
                     diffline = self.ui.popbuffer(labeled=True)
                 except:
+                    diffline = None
                     pass
 
                 if lines_to[0] <= self.line <= lines_to[0] + lines_to[1]:

--- a/blametrail.py
+++ b/blametrail.py
@@ -196,11 +196,7 @@ class changeset_printer(object):
                 lines_from = (int(m.group(1)), int(m.group(2)))
                 lines_to = (int(m.group(3)), int(m.group(4)))
 
-                try:
-                    diffline = self.ui.popbuffer(labeled=True)
-                except:
-                    diffline = None
-                    pass
+                diffline = self.ui.popbuffer()
 
                 if lines_to[0] <= self.line <= lines_to[0] + lines_to[1]:
                     # this is an interesting hunk!


### PR DESCRIPTION
I implemented some small changes to make the extension runnable on mercurial 4.0. `revset.formatspec` expects the revision expression to be a string. Additionally, the `popbuffer()` signature must have changed since the last revision of the extension: the parameter `labeled` is not allowed anymore.